### PR TITLE
Fix: kosync http headers

### DIFF
--- a/src/api_clients.py
+++ b/src/api_clients.py
@@ -136,7 +136,7 @@ class KoSyncClient:
             return False
 
     def get_progress(self, doc_id):
-        headers = {"x-auth-user": self.user, "x-auth-key": self.auth_token, 'accept': 'application/json'}
+        headers = {"x-auth-user": self.user, "x-auth-key": self.auth_token, 'accept': 'application/vnd.koreader.v1+json'}
         url = f"{self.base_url}/syncs/progress/{doc_id}"
         try:
             r = requests.get(url, headers=headers)
@@ -148,7 +148,7 @@ class KoSyncClient:
         return 0.0
 
     def update_progress(self, doc_id, percentage, xpath=None):
-        headers = {"x-auth-user": self.user, "x-auth-key": self.auth_token, 'accept': 'application/json', 'content-type': 'application/json'}
+        headers = {"x-auth-user": self.user, "x-auth-key": self.auth_token, 'accept': 'application/vnd.koreader.v1+json', 'content-type': 'application/json'}
         url = f"{self.base_url}/syncs/progress"
         
         # Use XPath if generated, otherwise fallback to percentage string


### PR DESCRIPTION
The kosync http endpoints require the accept and content type headers in order to work properly. This PR adds them for the kosync API request.