### PR TITLE
use resolve book path to get full path to book before running extract

### DIFF
--- a/src/ebook_utils.py
+++ b/src/ebook_utils.py
@@ -26,7 +26,7 @@ class EbookParser:
         self.hash_method = os.getenv("KOSYNC_HASH_METHOD", "content").lower()
         logger.info(f"Initialized EbookParser. ID Method: {self.hash_method}")
 
-    def _resolve_book_path(self, filename):
+    def resolve_book_path(self, filename):
         """
         Robustly finds a file in the books directory, handling special characters
         like [ ] (brackets) which break standard glob patterns.
@@ -164,7 +164,7 @@ class EbookParser:
     def find_text_location(self, filename, search_phrase):
         try:
             # FIXED: Use the new robust path resolver
-            book_path = self._resolve_book_path(filename)
+            book_path = self.resolve_book_path(filename)
             
             full_text, spine_map = self.extract_text_and_map(book_path)
             
@@ -269,7 +269,7 @@ class EbookParser:
     def get_text_at_percentage(self, filename, percentage):
         try:
             # FIXED: Use the new robust path resolver
-            book_path = self._resolve_book_path(filename)
+            book_path = self.resolve_book_path(filename)
             
             full_text, _ = self.extract_text_and_map(book_path)
             
@@ -291,7 +291,7 @@ class EbookParser:
 
     def get_character_delta(self, filename, percentage_prev, percentage_new):
         try:
-            book_path = self._resolve_book_path(filename)
+            book_path = self.resolve_book_path(filename)
         
             full_text, _ = self.extract_text_and_map(book_path)
             

--- a/src/main.py
+++ b/src/main.py
@@ -207,7 +207,8 @@ class SyncManager:
                     transcript_path = self.transcriber.process_audio(mapping['abs_id'], audio_files)
                     
                     logger.info("   Priming ebook cache...")
-                    self.ebook_parser.extract_text_and_map(mapping['ebook_filename'])
+                    book_path = self.ebook_parser.resolve_book_path(mapping['ebook_filename'])
+                    self.ebook_parser.extract_text_and_map(book_path)
 
                     mapping['transcript_file'] = str(transcript_path)
                     mapping['status'] = 'active'


### PR DESCRIPTION
Books in subfolders are not found by the existing extract code. This changes to use the function to pass the full path to the extract function